### PR TITLE
Added explicit USE_TZ setting.

### DIFF
--- a/settings/test_mariadb.py
+++ b/settings/test_mariadb.py
@@ -47,3 +47,4 @@ CACHES = {
 TEST_RUNNER = 'xmlrunner.extra.djangotestrunner.XMLTestRunner'
 TEST_OUTPUT_DIR = '/tests/results/'
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+USE_TZ = False

--- a/settings/test_mysql.py
+++ b/settings/test_mysql.py
@@ -47,3 +47,4 @@ CACHES = {
 TEST_RUNNER = 'xmlrunner.extra.djangotestrunner.XMLTestRunner'
 TEST_OUTPUT_DIR = '/tests/results/'
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+USE_TZ = False

--- a/settings/test_mysql_gis.py
+++ b/settings/test_mysql_gis.py
@@ -33,3 +33,4 @@ GEOIP_PATH = '/geolite2/'
 TEST_RUNNER = 'xmlrunner.extra.djangotestrunner.XMLTestRunner'
 TEST_OUTPUT_DIR = '/tests/results/'
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+USE_TZ = False

--- a/settings/test_oracle.py
+++ b/settings/test_oracle.py
@@ -49,3 +49,4 @@ CACHES = {
 TEST_RUNNER = 'xmlrunner.extra.djangotestrunner.XMLTestRunner'
 TEST_OUTPUT_DIR = '/tests/results/'
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+USE_TZ = False

--- a/settings/test_postgres.py
+++ b/settings/test_postgres.py
@@ -55,3 +55,4 @@ CACHES = {
 TEST_RUNNER = 'xmlrunner.extra.djangotestrunner.XMLTestRunner'
 TEST_OUTPUT_DIR = '/tests/results/'
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+USE_TZ = False

--- a/settings/test_postgres_gis.py
+++ b/settings/test_postgres_gis.py
@@ -41,3 +41,4 @@ GEOIP_PATH = '/geolite2/'
 TEST_RUNNER = 'xmlrunner.extra.djangotestrunner.XMLTestRunner'
 TEST_OUTPUT_DIR = '/tests/results'
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+USE_TZ = False

--- a/settings/test_sqlite.py
+++ b/settings/test_sqlite.py
@@ -48,3 +48,4 @@ CACHES = {
 TEST_RUNNER = 'xmlrunner.extra.djangotestrunner.XMLTestRunner'
 TEST_OUTPUT_DIR = '/tests/results'
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+USE_TZ = False

--- a/settings/test_sqlite_gis.py
+++ b/settings/test_sqlite_gis.py
@@ -33,3 +33,4 @@ GEOIP_PATH = '/geolite2/'
 TEST_RUNNER = 'xmlrunner.extra.djangotestrunner.XMLTestRunner'
 TEST_OUTPUT_DIR = '/tests/results/'
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+USE_TZ = False


### PR DESCRIPTION
The test suite currently crashes due to the warning:
> django.utils.deprecation.RemovedInDjango50Warning: The default value of USE_TZ will change from False to True in Django 5.0. Set USE_TZ to False in your project settings if you want to keep the current default behavior.

I guess it's best to not run the test suite under `USE_TZ = True` and just keep the old behaviour.