### PR TITLE
Fixed #29 -- Fixed crash of docs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
           libenchant-2-2 \
           gettext \
           wget \
+          git \
     && apt-get clean
 
 RUN groupadd -r test && useradd --no-log-init -r -g test test


### PR DESCRIPTION
Add git to dependencies for the Docker image, which is used in the `docs` target - and currently causes `docker-compose run docs` to fail.

Fixed #29 
