### PR TITLE
Remove misleading `docker-compose.yml` version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "2.3"
-
 x-base: &base
   image: djangobox/django-docker-box:${PYTHON_VERSION}
   build:


### PR DESCRIPTION
Docker Compose moved to a versionless spec for `docker-compose.yml` a fair few years back now. AFAIK, Any modern Docker Compose will ignore the `version`, and will show a warning if one is defined. Looking up the `docker-compose.yml` 'versions' can lead one to inaccurate obsolete docs / information. 