### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,14 +31,14 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.2
+    rev: v0.12.0
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix, --fix]
       - id: ruff-format
         args: [--check]
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.35.1
+    rev: v1.37.1
     hooks:
       - id: yamllint
         args: [--strict]
@@ -48,6 +48,6 @@ repos:
       - id: hadolint-docker
         name: hadolint
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v0.9.2
+    rev: v1.9.0
     hooks:
       - id: zizmor


### PR DESCRIPTION
- ruff-pre-commit: from v0.8.2 to v0.12.0
- yamllint: from v1.35.1 to v1.37.1
- zizmor-pre-commit: from v0.9.2 to v1.9.0